### PR TITLE
Partially solves #5, using spaces in formatting

### DIFF
--- a/nunit.vssettings
+++ b/nunit.vssettings
@@ -51,13 +51,13 @@
                 <PropertyValue name="Space_BetweenEmptyMethodCallParentheses">0</PropertyValue>
                 <PropertyValue name="Space_BetweenEmptyMethodDeclarationParentheses">0</PropertyValue>
                 <PropertyValue name="Space_BetweenEmptySquares">0</PropertyValue>
-                <PropertyValue name="Space_InControlFlowConstruct">0</PropertyValue>
+                <PropertyValue name="Space_InControlFlowConstruct">1</PropertyValue>
                 <PropertyValue name="Space_Normalize">0</PropertyValue>
                 <PropertyValue name="Space_WithinCastParentheses">0</PropertyValue>
                 <PropertyValue name="Space_WithinExpressionParentheses">0</PropertyValue>
                 <PropertyValue name="Space_WithinMethodCallParentheses">0</PropertyValue>
                 <PropertyValue name="Space_WithinMethodDeclarationParentheses">0</PropertyValue>
-                <PropertyValue name="Space_WithinOtherParentheses">1</PropertyValue>
+                <PropertyValue name="Space_WithinOtherParentheses">0</PropertyValue>
                 <PropertyValue name="Space_WithinSquares">0</PropertyValue>
                 <PropertyValue name="Wrapping_IgnoreSpacesAroundBinaryOperators">0</PropertyValue>
                 <PropertyValue name="Wrapping_IgnoreSpacesAroundVariableDeclaration">0</PropertyValue>


### PR DESCRIPTION
I'm a bit later, but here's the fix for some space settings that, as I noticed were, didn't comply with the coding standards of nunit. The inconsistencies were mentioned in detail in #5.

Please note that this pull request only contains fixes for space issues; I didn't address other points raised in the #5(like full review to the whole settings to make sure they conform to what's dictated in the coding standards).